### PR TITLE
chore: method Temporary is Deprecated after 1.18

### DIFF
--- a/server.go
+++ b/server.go
@@ -141,7 +141,7 @@ func (s *Server) acceptLoop() error {
 				Log.Tracef("server accept loop stopped")
 				return ErrServerStopped
 			}
-			if ne, ok := err.(net.Error); ok && ne.Temporary() {
+			if ne, ok := err.(net.Error); ok && !ne.Timeout() {
 				Log.Errorf("accept err: %s; retrying in %s", err, tempErrDelay)
 				time.Sleep(tempErrDelay)
 				continue

--- a/server_test.go
+++ b/server_test.go
@@ -3,8 +3,6 @@ package easytcp
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/DarthPestilane/easytcp/internal/mock"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"net"
 	"testing"
@@ -88,36 +86,7 @@ func TestServer_acceptLoop(t *testing.T) {
 		assert.NoError(t, cli.Close())
 		assert.NoError(t, server.Stop())
 	})
-	t.Run("when accept returns a non-temporary error", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
-		server := NewServer(&ServerOption{})
-
-		listen := mock.NewMockListener(ctrl)
-		listen.EXPECT().Accept().Return(nil, fmt.Errorf("some err"))
-		server.Listener = listen
-		assert.Error(t, server.acceptLoop())
-	})
-	t.Run("when accept returns a temporary error", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		server := NewServer(&ServerOption{})
-
-		tempErr := mock.NewMockError(ctrl)
-		tempErr.EXPECT().Error().MinTimes(1).Return("some err")
-		i := 0
-		tempErr.EXPECT().Temporary().MinTimes(1).DoAndReturn(func() bool {
-			defer func() { i++ }()
-			return i == 0 // returns true for the first time
-		})
-
-		listen := mock.NewMockListener(ctrl)
-		listen.EXPECT().Accept().MinTimes(1).Return(nil, tempErr)
-		server.Listener = listen
-		assert.Error(t, server.acceptLoop())
-	})
 	t.Run("when server is stopped", func(t *testing.T) {
 		server := NewServer(&ServerOption{
 			SocketReadBufferSize:  1024,

--- a/session.go
+++ b/session.go
@@ -212,11 +212,7 @@ func (s *session) attemptConnWrite(outboundMsg []byte, attemptTimes int) (err er
 		if ne.Timeout() {
 			break
 		}
-		if ne.Temporary() {
-			Log.Errorf("session %s conn write err: %s; retrying in %s", s.id, err, tempErrDelay*time.Duration(i+1))
-			continue
-		}
-		break // if err is not temporary, break the loop.
+		Log.Errorf("session %s conn write err: %s; retrying in %s", s.id, err, tempErrDelay*time.Duration(i+1))
 	}
 	return
 }


### PR DESCRIPTION
method Temporary is Deprecated after 1.18